### PR TITLE
Provided block parameter with true.

### DIFF
--- a/src/main/resources/project/jython/start_cluster.jython
+++ b/src/main/resources/project/jython/start_cluster.jython
@@ -16,7 +16,7 @@
 
 def startCluster(clustername):
     try:
-        start(clustername,"Cluster");
+        start(clustername, "Cluster", block='true');
     except Exception, e:
         print 'Error while starting cluster', e
         dumpStack()


### PR DESCRIPTION
Start function in our case already has block parameter = true.
This parameter is forced to be true to avoid confusions and context-dependent behavior.