### PR TITLE
Named sessions are disabled for weblogic server with version < 12.

### DIFF
--- a/pages/EC-WebLogic_help.xml
+++ b/pages/EC-WebLogic_help.xml
@@ -157,7 +157,7 @@
                         <tr>
                             <td>Enable named sessions?</td>
                             <td>
-                                If checked, each WebLogic edit session will have unique name assigned. Defaults to false.
+                                If checked, each WebLogic edit session will have unique name assigned. Named sessions are not supported by WebLogic server prior to 12 version. Defaults to false.
                             </td>
                         </tr>
                         <tr>

--- a/src/main/resources/project/WebLogicCreateConfigForm.xml
+++ b/src/main/resources/project/WebLogicCreateConfigForm.xml
@@ -67,7 +67,7 @@ limitations under the License.
         <value>0</value>
         <required>0</required>
         <documentation>
-            If checked, each WebLogic edit session will have unique name assigned. Defaults to false.
+            If checked, each WebLogic edit session will have unique name assigned. Named sessions are not supported by WebLogic server prior to 12 version. Defaults to false.
         </documentation>
     </formElement>
     <formElement>

--- a/src/main/resources/project/WebLogicEditConfigForm.xml
+++ b/src/main/resources/project/WebLogicEditConfigForm.xml
@@ -60,7 +60,7 @@ limitations under the License.
         <value>0</value>
         <required>0</required>
         <documentation>
-            If checked, each WebLogic edit session will have unique name assigned. Defaults to false.
+            If checked, each WebLogic edit session will have unique name assigned. Named sessions are not supported by WebLogic server prior to 12 version. Defaults to false.
         </documentation>
     </formElement>
     <formElement>

--- a/src/main/resources/project/jython/preamble.jython
+++ b/src/main/resources/project/jython/preamble.jython
@@ -82,7 +82,6 @@ def commitChanges(lockTimeout = None):
     activate(**params)
     if isNamedSessionEnabled():
         print "Terminating edit session %s" % (randSessionName)
-        # destroyEditSession(randSessionName)
         terminateEditSession(randSessionName)
 
 
@@ -90,7 +89,6 @@ def discardChanges():
     stopEdit('y')
     if isNamedSessionEnabled():
         print "Terminating edit session %s" % (randSessionName)
-        # destroyEditSession(randSessionName)
         terminateEditSession(randSessionName)
 
 # add parse function

--- a/src/main/resources/project/jython/preamble.jython
+++ b/src/main/resources/project/jython/preamble.jython
@@ -29,7 +29,7 @@ def determineWebLogicVersion():
     versionNumber = int(result.group(1))
     return versionNumber
 
-def terminateEdiSession(sessionName):
+def terminateEditSession(sessionName):
     wlVersion = determineWebLogicVersion()
     if wlVersion < 12:
         print "WARNING" + ':' + "Named Sessions are not available prior to Weblogic Server 12. Your version is: " + version
@@ -83,7 +83,7 @@ def commitChanges(lockTimeout = None):
     if isNamedSessionEnabled():
         print "Terminating edit session %s" % (randSessionName)
         # destroyEditSession(randSessionName)
-        terminateEdiSession(randSessionName)
+        terminateEditSession(randSessionName)
 
 
 def discardChanges():
@@ -91,7 +91,7 @@ def discardChanges():
     if isNamedSessionEnabled():
         print "Terminating edit session %s" % (randSessionName)
         # destroyEditSession(randSessionName)
-        terminateEdiSession(randSessionName)
+        terminateEditSession(randSessionName)
 
 # add parse function
 def parseOptions(options):

--- a/src/main/resources/project/jython/preamble.jython
+++ b/src/main/resources/project/jython/preamble.jython
@@ -23,10 +23,27 @@ import random
 import time as pytime
 
 # end of imports
+print "WebLogic version is: %s" % (version)
+def determineWebLogicVersion():
+    result = re.match('^\s*?WebLogic\sServer\s(\d+)', version)
+    versionNumber = int(result.group(1))
+    return versionNumber
 
+def terminateEdiSession(sessionName):
+    wlVersion = determineWebLogicVersion()
+    if wlVersion < 12:
+        print "WARNING" + ':' + "Named Sessions are not available prior to Weblogic Server 12. Your version is: " + version
+    else:
+        destroyEditSession(sessionName)
+    return 1
+    
 def isNamedSessionEnabled():
     if [% enable_named_sessions %]:
-        return 1
+        if determineWebLogicVersion() < 12:
+            print "WARNING" + ':' + "Named Sessions are not available prior to Weblogic Server 12. Your version is: " + version
+            return 0
+        else:
+            return 1
     else:
         return 0
 
@@ -65,14 +82,16 @@ def commitChanges(lockTimeout = None):
     activate(**params)
     if isNamedSessionEnabled():
         print "Terminating edit session %s" % (randSessionName)
-        destroyEditSession(randSessionName)
+        # destroyEditSession(randSessionName)
+        terminateEdiSession(randSessionName)
 
 
 def discardChanges():
     stopEdit('y')
     if isNamedSessionEnabled():
         print "Terminating edit session %s" % (randSessionName)
-        destroyEditSession(randSessionName)
+        # destroyEditSession(randSessionName)
+        terminateEdiSession(randSessionName)
 
 # add parse function
 def parseOptions(options):


### PR DESCRIPTION
See weblogic release reference: https://docs.oracle.com/middleware/1221/wls/NOTES/whatsnew.htm\#NOTES520 section: "New Edit Session Commands" + added version weblogic version output.